### PR TITLE
remove empty lines at beginning of elisp libraries

### DIFF
--- a/lisp/ediff-batch.el
+++ b/lisp/ediff-batch.el
@@ -1,4 +1,3 @@
-
 ;;; ediff-batch.el --- helper for ediff(1) and ediff-merge(1)
 ;;
 ;; Copyright (c) 2012, 2013 Akinori MUSHA

--- a/lisp/emacsc.el
+++ b/lisp/emacsc.el
@@ -1,4 +1,3 @@
-
 ;;; emacsc.el --- helper for emacsc(1)
 ;;
 ;; Copyright (c) 2012, 2013 Akinori MUSHA


### PR DESCRIPTION
The summary line is supposed to be the first line; if it is not,
then tools that are supposed to extract the summary fail to do so.